### PR TITLE
Fix Tools menu disappearing when using SD2 for ROMs

### DIFF
--- a/files/ROOTFS/opt/system/Advanced/Switch to SD2 for Roms.sh
+++ b/files/ROOTFS/opt/system/Advanced/Switch to SD2 for Roms.sh
@@ -38,7 +38,7 @@ if [ "$filesystem" = "ntfs" ]; then
 	filesystem="ntfs-3g"
 fi
 
-sudo umount /opt/system/Tools
+# Keep /opt/system/Tools mounted from main SD - tools are system scripts, not ROMs
 
 if [ "$filesystem" = "ext4" ]; then
    sudo mount -t $filesystem $blklocation /roms2
@@ -61,14 +61,13 @@ then
   if [ ! -d "/roms2/videos/" ]; then
       sudo mkdir /roms2/videos
   fi
-  sudo mount -B /roms2/tools /opt/system/Tools
+  # Tools stay mounted from /roms/tools (main SD) via fstab
   sed -i '/<path>\/roms\//s//<path>\/roms2\//' /etc/emulationstation/es_systems.cfg
   if [ "$filesystem" = "ext4" ]; then
      sudo sed -i '$a\/'"$blklocationforsed"' \/roms2 '"$filesystem"' defaults,nofail,x-systemd.device-timeout=7 0 1' /etc/fstab
   else
      sudo sed -i '$a\/'"$blklocationforsed"' \/roms2 '"$filesystem"' umask=0000,iocharset=utf8,noatime,nofail,x-systemd.device-timeout=7,uid=1000,gid=1000 0 0' /etc/fstab
   fi
-  sudo sed -i '/roms\/tools/s//roms2\/tools/' /etc/fstab
   sudo sed -i '/roms\/pico-8/s//roms2\/pico-8/g' /usr/local/bin/pico8.sh
   sudo sed -i '/roms\//s//roms2\//g' /usr/local/bin/scummvm.sh
   sudo sed -i '/roms\//s//roms2\//g' /usr/local/bin/ti99.sh

--- a/files/ROOTFS/usr/local/bin/Switch to Main SD for Roms.sh
+++ b/files/ROOTFS/usr/local/bin/Switch to Main SD for Roms.sh
@@ -20,7 +20,6 @@ if [ "$filesystem" = "ntfs" ]; then
 	filesystem="ntfs-3g"
 fi
 
-sudo umount /opt/system/Tools
 sudo mount -t $filesystem /dev/mmcblk1p5 /roms -o uid=1000
 status=$?
 
@@ -29,10 +28,9 @@ status=$?
   if [ ! -d "/roms/videos/" ]; then
       sudo mkdir /roms/videos
   fi
-  sudo mount -B /roms/tools /opt/system/Tools
+  # Tools remain mounted from /roms/tools (main SD) - no remount needed
   sed -i '/<path>\/roms2\//s//<path>\/roms\//' /etc/emulationstation/es_systems.cfg
   sudo sed -i '/roms2\/pico-8/s//roms\/pico-8/g' /usr/local/bin/pico8.sh
-  sudo sed -i '/roms2\/tools/s//roms\/tools/' /etc/fstab
   sudo sed -i '/roms2\//s//roms\//g' /usr/local/bin/scummvm.sh
   sudo sed -i '/roms2\//s//roms\//g' /usr/local/bin/ti99.sh
   sudo sed -i '/roms2\//s//roms\//g' /usr/local/bin/doom.sh
@@ -90,7 +88,7 @@ status=$?
   unlink /home/ark/.config/ppsspp
   ln -sf /roms/psp/ppsspp/ /home/ark/.config/ppsspp
   sudo cp /usr/local/bin/Switch\ to\ SD2\ for\ Roms.sh /opt/system/Advanced/.
-  sudo rm /opt/system/Advanced/Switch\ to\ main\ SD\ for\ Roms.sh
+  sudo rm /opt/system/Advanced/Switch\ to\ Main\ SD\ for\ Roms.sh
   sudo cp -f /etc/samba/smb.conf.orig /etc/samba/smb.conf
   sudo umount /roms2
   sudo pkill filebrowser

--- a/files/ROOTFS/usr/local/bin/Switch to SD2 for Roms.sh
+++ b/files/ROOTFS/usr/local/bin/Switch to SD2 for Roms.sh
@@ -38,7 +38,7 @@ if [ "$filesystem" = "ntfs" ]; then
 	filesystem="ntfs-3g"
 fi
 
-sudo umount /opt/system/Tools
+# Keep /opt/system/Tools mounted from main SD - tools are system scripts, not ROMs
 
 if [ "$filesystem" = "ext4" ]; then
    sudo mount -t $filesystem $blklocation /roms2
@@ -61,14 +61,13 @@ then
   if [ ! -d "/roms2/videos/" ]; then
       sudo mkdir /roms2/videos
   fi
-  sudo mount -B /roms2/tools /opt/system/Tools
+  # Tools stay mounted from /roms/tools (main SD) via fstab
   sed -i '/<path>\/roms\//s//<path>\/roms2\//' /etc/emulationstation/es_systems.cfg
   if [ "$filesystem" = "ext4" ]; then
      sudo sed -i '$a\/'"$blklocationforsed"' \/roms2 '"$filesystem"' defaults,nofail,x-systemd.device-timeout=7 0 1' /etc/fstab
   else
      sudo sed -i '$a\/'"$blklocationforsed"' \/roms2 '"$filesystem"' umask=0000,iocharset=utf8,noatime,nofail,x-systemd.device-timeout=7,uid=1000,gid=1000 0 0' /etc/fstab
   fi
-  sudo sed -i '/roms\/tools/s//roms2\/tools/' /etc/fstab
   sudo sed -i '/roms\/pico-8/s//roms2\/pico-8/g' /usr/local/bin/pico8.sh
   sudo sed -i '/roms\//s//roms2\//g' /usr/local/bin/scummvm.sh
   sudo sed -i '/roms\//s//roms2\//g' /usr/local/bin/ti99.sh


### PR DESCRIPTION
## Summary

Two bugs in the SD card switching scripts:

1. **Tools menu (ThemeMaster, PortMaster) disappears after switching to SD2 for ROMs.** The switch script unmounts `/opt/system/Tools` and tries to bind-mount from `/roms2/tools`, which doesn't exist on SD2. Tools are system scripts that live on the main SD card — they should stay mounted from `/roms/tools` regardless of which SD is used for ROM storage.

2. **Both "Switch to SD2" and "Switch to Main SD" options appear in the menu after switching back to main SD.** Case mismatch in the `rm` command — `Switch to main SD` (lowercase m) vs actual filename `Switch to Main SD` (uppercase M) — so the script never removes itself from the Advanced menu.

## Changes

- Stop unmounting/remounting `/opt/system/Tools` during SD switching
- Remove the fstab sed that rewrites the tools mount path
- Fix case mismatch in `Switch to Main SD for Roms.sh` self-removal

## Testing

Tested on R36S (G80CA-MB V1.2) — switched to SD2, confirmed Tools menu remains visible with ThemeMaster and PortMaster available. Switched back to main SD, confirmed only the correct switch option appears.